### PR TITLE
feat: DataTable filter

### DIFF
--- a/app/components/columns/zone.tsx
+++ b/app/components/columns/zone.tsx
@@ -38,6 +38,25 @@ export const columns: ColumnDef<ZoneRow>[] = [
     enableHiding: false,
   },
   {
+    id: "account",
+    header: "Account",
+    accessorFn: ({ zone }) => zone.account.businessName,
+    cell: (props) => {
+      return <AccountLink data={props.row.original.zone.account} />;
+    },
+    meta: {
+      filter: "select",
+    },
+  },
+  {
+    id: "location",
+    header: "Location",
+    accessorFn: ({ zone }) => zone.location.name,
+    meta: {
+      filter: "select",
+    },
+  },
+  {
     id: "zone",
     header: "Zone",
     filterFn: "includesString",
@@ -52,25 +71,6 @@ export const columns: ColumnDef<ZoneRow>[] = [
           }}
         />
       );
-    },
-  },
-  {
-    id: "location",
-    header: "Location",
-    accessorFn: ({ zone }) => zone.location.name,
-    meta: {
-      filter: "select",
-    },
-  },
-  {
-    id: "account",
-    header: "Account",
-    accessorFn: ({ zone }) => zone.account.businessName,
-    cell: (props) => {
-      return <AccountLink data={props.row.original.zone.account} />;
-    },
-    meta: {
-      filter: "select",
     },
   },
   {

--- a/app/routes/events.$id.tsx
+++ b/app/routes/events.$id.tsx
@@ -102,14 +102,16 @@ export default function Event() {
   const { mutate } = useSWRConfig();
 
   const { data: event, error } = useSWR(eventKey, eventFetcher);
-  const { data: accounts, error: accountsError } = useSWR(
-    "/api/v1/accounts",
-    accountsFetcher,
-  );
-  const { data: zones, error: zonesError } = useSWR(
-    "/api/v1/zones",
-    zonesFetcher,
-  );
+  const {
+    data: accounts,
+    error: accountsError,
+    isLoading: isLoadingAccount,
+  } = useSWR("/api/v1/accounts", accountsFetcher);
+  const {
+    data: zones,
+    error: zonesError,
+    isLoading: isLoadingZones,
+  } = useSWR("/api/v1/zones", zonesFetcher);
 
   const { trigger: destroyTrigger, error: destroyError } = useSWRMutation(
     eventKey,
@@ -285,6 +287,8 @@ export default function Event() {
               <DataTable
                 pagination
                 columns={zoneColumns}
+                loading={isLoadingZones || isLoadingAccount}
+                loadingRows={event.zones.length}
                 data={
                   zoneMap
                     ? (activeZoneIds
@@ -319,6 +323,8 @@ export default function Event() {
               <DataTable
                 pagination
                 columns={zoneColumns}
+                loading={isLoadingZones || isLoadingAccount}
+                loadingRows={10} // Page size
                 data={
                   (zonesWithAccount
                     ?.filter((zone) => !activeZoneIds.includes(zone.id))


### PR DESCRIPTION
### Filter component

Changes the DataTable filter for `select` filter modes to use a `Command` component with search instead of a normal `Select` component.

### Column reorder

Reorders the zone columns to show

| Checkbox | Account | Location | Zone | Actions |
| - | - | - | - | - |
| `<inpyt type="checkbox">` | My account | My location | My zone | `<button>` |

### Loading state

DataTable now accepts a `loading?: boolean` and `loadingRows?: number` that will render `Skeleton` rows while `loading` is `true`.